### PR TITLE
Consistent treatment of fluxes for Neumann BC

### DIFF
--- a/mpfa.m
+++ b/mpfa.m
@@ -219,7 +219,7 @@ dir_ind_eq = find(excludeNeumann * isDirichlet(fnoGlob));
 dir_ind_glob = find(isDirichlet(fnoGlob));
 
 % The right hand sides should consider the equation based numbering
-ccNeu = sparse(neu_ind_eq, 1:numel(neu_ind_eq), sgn(neu_ind_glob) .*G.faces.areas(fnoGlob(neu_ind_eq))...
+ccNeu = sparse(neu_ind_eq, 1:numel(neu_ind_eq), sgn(neu_ind_glob) ...
     ./nFaceNodes(fnoGlob(neu_ind_eq)), size(nK, 1), nNeu+nDir);
 ccDir = sparse(dir_ind_eq,nNeu+(1:numel(dir_ind_eq)),(sgn(dir_ind_glob).^1), size(pContCC,1), nNeu+nDir);
 


### PR DESCRIPTION
Eirik, I remember this was a bug that I've changed only locally for my Master's. However, this fix is crucial for recovering correct fluxes at the boundaries while imposing Neumann BC. There is also a similar change for MPSA.